### PR TITLE
Introduce basic ni logging

### DIFF
--- a/pkg/cmd/log.go
+++ b/pkg/cmd/log.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"fmt"
-	"io"
-	"os"
-
+	"github.com/puppetlabs/nebula-sdk/pkg/log"
 	"github.com/spf13/cobra"
 )
 
@@ -15,46 +12,56 @@ func NewLogCommand() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 
-	cmd.AddCommand(NewLogLevelCommand(LogLevelInfo, "Logs a general message"))
-	cmd.AddCommand(NewLogLevelCommand(LogLevelWarning, "Logs a warning message"))
-	cmd.AddCommand(NewLogLevelCommand(LogLevelError, "Logs an error message"))
-	cmd.AddCommand(NewLogLevelCommand(LogLevelFatal, "Logs an error message and forces termination of step container"))
+	cmd.AddCommand(NewLogInfoCommand())
+	cmd.AddCommand(NewLogWarnCommand())
+	cmd.AddCommand(NewLogErrorCommand())
+	cmd.AddCommand(NewLogFatalCommand())
 
 	return cmd
 }
 
-type LogLevel string
-
-const (
-	LogLevelInfo    LogLevel = "info"
-	LogLevelWarning LogLevel = "warn"
-	LogLevelError   LogLevel = "error"
-	LogLevelFatal   LogLevel = "fatal"
-)
-
-func NewLogLevelCommand(level LogLevel, description string) *cobra.Command {
+func NewLogInfoCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   string(level),
-		Short: description,
+		Use:   string(log.LogLevelInfo),
+		Short: "Logs an informational message",
 		Run: func(cmd *cobra.Command, args []string) {
-			// This is a stub for eventual forwarding of these log messages to nebula for collection and reporting
+			log.Info(args[0])
+		},
+	}
 
-			var writer io.Writer
+	return cmd
+}
 
-			if level == LogLevelInfo {
-				writer = cmd.OutOrStdout()
-			} else {
-				writer = cmd.ErrOrStderr()
-			}
+func NewLogWarnCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   string(log.LogLevelWarn),
+		Short: "Logs a warning message",
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Warn(args[0])
+		},
+	}
 
-			fmt.Fprintln(
-				writer,
-				args[0],
-			)
+	return cmd
+}
 
-			if level == LogLevelFatal {
-				os.Exit(1)
-			}
+func NewLogErrorCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   string(log.LogLevelError),
+		Short: "Logs an error message",
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Error(args[0])
+		},
+	}
+
+	return cmd
+}
+
+func NewLogFatalCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   string(log.LogLevelFatal),
+		Short: "Logs a fatal error message and exits process",
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Fatal(args[0])
 		},
 	}
 

--- a/pkg/cmd/log.go
+++ b/pkg/cmd/log.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func NewLogCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "log",
+		Short:                 "Submit annotated log messages",
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.AddCommand(NewLogLevelCommand(LogLevelInfo, "Logs a general message"))
+	cmd.AddCommand(NewLogLevelCommand(LogLevelWarning, "Logs a warning message"))
+	cmd.AddCommand(NewLogLevelCommand(LogLevelError, "Logs an error message"))
+	cmd.AddCommand(NewLogLevelCommand(LogLevelFatal, "Logs an error message and forces termination of step container"))
+
+	return cmd
+}
+
+type LogLevel string
+
+const (
+	LogLevelInfo    LogLevel = "info"
+	LogLevelWarning LogLevel = "warn"
+	LogLevelError   LogLevel = "error"
+	LogLevelFatal   LogLevel = "fatal"
+)
+
+func NewLogLevelCommand(level LogLevel, description string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   string(level),
+		Short: description,
+		Run: func(cmd *cobra.Command, args []string) {
+			// This is a stub for eventual forwarding of these log messages to nebula for collection and reporting
+
+			var writer io.Writer
+
+			if level == LogLevelInfo {
+				writer = cmd.OutOrStdout()
+			} else {
+				writer = cmd.ErrOrStderr()
+			}
+
+			fmt.Fprintln(
+				writer,
+				args[0],
+			)
+
+			if level == LogLevelFatal {
+				os.Exit(1)
+			}
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/log.go
+++ b/pkg/cmd/log.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/puppetlabs/nebula-sdk/pkg/log"
 	"github.com/spf13/cobra"
 )
@@ -24,8 +26,9 @@ func NewLogInfoCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   string(log.LogLevelInfo),
 		Short: "Logs an informational message",
+		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			log.Info(args[0])
+			log.Info(strings.Join(args, " "))
 		},
 	}
 
@@ -36,8 +39,9 @@ func NewLogWarnCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   string(log.LogLevelWarn),
 		Short: "Logs a warning message",
+		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			log.Warn(args[0])
+			log.Warn(strings.Join(args, " "))
 		},
 	}
 
@@ -48,8 +52,9 @@ func NewLogErrorCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   string(log.LogLevelError),
 		Short: "Logs an error message",
+		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			log.Error(args[0])
+			log.Error(strings.Join(args, " "))
 		},
 	}
 
@@ -60,8 +65,9 @@ func NewLogFatalCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   string(log.LogLevelFatal),
 		Short: "Logs a fatal error message and exits process",
+		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			log.Fatal(args[0])
+			log.Fatal(strings.Join(args, " "))
 		},
 	}
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -19,6 +19,7 @@ func NewRootCommand() (*cobra.Command, error) {
 	c.AddCommand(NewGitCommand())
 	c.AddCommand(NewAWSCommand())
 	c.AddCommand(NewOutputCommand())
+	c.AddCommand(NewLogCommand())
 
 	return c, nil
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,46 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+type LogLevel string
+
+const (
+	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warn"
+	LogLevelError LogLevel = "error"
+	LogLevelFatal LogLevel = "fatal"
+)
+
+// Log prints tagged log messages. It is a stub for future reporting of
+// such messages to the nebula service
+func Log(writer io.Writer, level LogLevel, log string) {
+	fmt.Fprintln(
+		writer,
+		log,
+	)
+}
+
+// Info reports an informational log
+func Info(log string) {
+	Log(os.Stdout, LogLevelInfo, log)
+}
+
+// Warn reports a warning
+func Warn(log string) {
+	Log(os.Stderr, LogLevelWarn, log)
+}
+
+// Error reports an error
+func Error(log string) {
+	Log(os.Stderr, LogLevelError, log)
+}
+
+// Fatal reports a fatal error then exits the process
+func Fatal(log string) {
+	Log(os.Stderr, LogLevelFatal, log)
+	os.Exit(1)
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -17,7 +17,7 @@ const (
 
 // Log prints tagged log messages. It is a stub for future reporting of
 // such messages to the nebula service
-func Log(writer io.Writer, level LogLevel, log string) {
+func writeLog(writer io.Writer, level LogLevel, log string) {
 	fmt.Fprintln(
 		writer,
 		log,
@@ -26,21 +26,21 @@ func Log(writer io.Writer, level LogLevel, log string) {
 
 // Info reports an informational log
 func Info(log string) {
-	Log(os.Stdout, LogLevelInfo, log)
+	writeLog(os.Stdout, LogLevelInfo, log)
 }
 
 // Warn reports a warning
 func Warn(log string) {
-	Log(os.Stderr, LogLevelWarn, log)
+	writeLog(os.Stderr, LogLevelWarn, log)
 }
 
 // Error reports an error
 func Error(log string) {
-	Log(os.Stderr, LogLevelError, log)
+	writeLog(os.Stderr, LogLevelError, log)
 }
 
 // Fatal reports a fatal error then exits the process
 func Fatal(log string) {
-	Log(os.Stderr, LogLevelFatal, log)
+	writeLog(os.Stderr, LogLevelFatal, log)
 	os.Exit(1)
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -17,10 +17,10 @@ const (
 
 // Log prints tagged log messages. It is a stub for future reporting of
 // such messages to the nebula service
-func writeLog(writer io.Writer, level LogLevel, log string) {
+func writeLog(writer io.Writer, level LogLevel, log ...interface{}) {
 	fmt.Fprintln(
 		writer,
-		log,
+		log...,
 	)
 }
 
@@ -29,9 +29,19 @@ func Info(log string) {
 	writeLog(os.Stdout, LogLevelInfo, log)
 }
 
+// InfoE reports an informational log from a go error
+func InfoE(err error) {
+	writeLog(os.Stderr, LogLevelInfo, err)
+}
+
 // Warn reports a warning
 func Warn(log string) {
 	writeLog(os.Stderr, LogLevelWarn, log)
+}
+
+// WarnE reports a warning from a go error
+func WarnE(err error) {
+	writeLog(os.Stderr, LogLevelWarn, err)
 }
 
 // Error reports an error
@@ -39,8 +49,19 @@ func Error(log string) {
 	writeLog(os.Stderr, LogLevelError, log)
 }
 
+// ErrorE reports an error from a go error
+func ErrorE(err error) {
+	writeLog(os.Stderr, LogLevelError, err)
+}
+
 // Fatal reports a fatal error then exits the process
 func Fatal(log string) {
 	writeLog(os.Stderr, LogLevelFatal, log)
+	os.Exit(1)
+}
+
+// FatalE reports a fatal error from a go error then exits the process
+func FatalE(err error) {
+	writeLog(os.Stderr, LogLevelFatal, err)
 	os.Exit(1)
 }


### PR DESCRIPTION
Introduces ni logging with four levels (info, warn, error, fatal) that can be used in the form `ni log <level> <log message>`. At present it is only a stub, which will print messages and return a non-zero error code in the fatal case.