### PR TITLE
Fixes regex that forces a git ssh url to have .git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1]
+
+### Changed
+
+* Fix: Make .git at the end of a Git SSH URL optional.
+* Fix: Make the username portion of a Git SSH URL dynamic. You are no longer
+  required to use `git` as the username.
+
 ## [1.5.0]
 
 ### Added
@@ -57,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Public release of the `ni` command.
 
-[Unreleased]: https://github.com/puppetlabs/nebula-sdk/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/puppetlabs/nebula-sdk/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/puppetlabs/nebula-sdk/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/puppetlabs/nebula-sdk/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/puppetlabs/nebula-sdk/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/puppetlabs/nebula-sdk/compare/v1.2.0...v1.3.0

--- a/pkg/task/git_test.go
+++ b/pkg/task/git_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/puppetlabs/nebula-sdk/pkg/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGitOutput(t *testing.T) {
@@ -32,4 +33,33 @@ func TestGitOutput(t *testing.T) {
 		// err := task.CloneRepository("master", "output")
 		// require.Nil(t, err, "err is not nil")
 	}, opts)
+}
+
+func TestGitURLMatching(t *testing.T) {
+	cases := []struct {
+		gitURL      string
+		shouldMatch bool
+	}{
+		{gitURL: "git@github.com:example/example-repo", shouldMatch: true},
+		{gitURL: "git@github.com:example/example-repo.git", shouldMatch: true},
+		{gitURL: "git@github.com/example/example-repo.git", shouldMatch: false},
+		{gitURL: "foobar@github.com:example/example-repo", shouldMatch: true},
+		{gitURL: "foobar@github.com:example/example-repo.git", shouldMatch: true},
+		{gitURL: "foobar@github.com/example/example-repo.git", shouldMatch: false},
+		{gitURL: "https://example.com", shouldMatch: false},
+		{gitURL: "git@example.com:example-org/example-repo", shouldMatch: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.gitURL, func(t *testing.T) {
+			matches, err := gitURLComponents(c.gitURL)
+
+			if !c.shouldMatch {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.GreaterOrEqual(t, len(matches), 4)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Also makes the username for the ssh url dynamic.

The git ssh url regex was not allowing URLs that do not end in .git to
be used. This commit allows a URL to be structures either as
git@github.com:example/example.git or git@github.com:example/example.

It also makes the username portion of the URL to be dynamic, which will
allow this feature to be used for many self-hosted git repo management
platforms like gitea and gitlab, where the username can be changed.