### PR TITLE
Naively convert ni get to http query

### DIFF
--- a/pkg/cmd/aws.go
+++ b/pkg/cmd/aws.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -32,7 +31,7 @@ func NewAWSConfigCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			directory, _ := cmd.Flags().GetString("directory")
 
-			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: taskutil.MetadataSpecURL()}
 			task := task.NewTaskInterface(planOpts)
 			return task.ProcessAWS(directory)
 		},

--- a/pkg/cmd/cluster.go
+++ b/pkg/cmd/cluster.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/puppetlabs/nebula-sdk/pkg/task"
 	"github.com/puppetlabs/nebula-sdk/pkg/taskutil"
 	"github.com/spf13/cobra"
@@ -28,7 +26,7 @@ func NewClusterConfigCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			directory, _ := cmd.Flags().GetString("directory")
 
-			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: taskutil.MetadataSpecURL()}
 			task := task.NewTaskInterface(planOpts)
 			return task.ProcessClusters(directory)
 		},

--- a/pkg/cmd/credentials.go
+++ b/pkg/cmd/credentials.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/puppetlabs/nebula-sdk/pkg/task"
 	"github.com/puppetlabs/nebula-sdk/pkg/taskutil"
 	"github.com/spf13/cobra"
@@ -28,7 +26,7 @@ func NewCredentialsConfigCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			directory, _ := cmd.Flags().GetString("directory")
 
-			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: taskutil.MetadataSpecURL()}
 			task := task.NewTaskInterface(planOpts)
 			return task.ProcessCredentials(directory)
 		},

--- a/pkg/cmd/file.go
+++ b/pkg/cmd/file.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/puppetlabs/nebula-sdk/pkg/task"
 	"github.com/puppetlabs/nebula-sdk/pkg/taskutil"
 	"github.com/spf13/cobra"
@@ -18,7 +16,7 @@ func NewFileCommand() *cobra.Command {
 			path, _ := cmd.Flags().GetString("path")
 			output, _ := cmd.Flags().GetString("output")
 
-			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: taskutil.MetadataSpecURL()}
 			task := task.NewTaskInterface(planOpts)
 			return task.WriteFile(file, path, output)
 		},

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/puppetlabs/nebula-sdk/pkg/task"
 	"github.com/puppetlabs/nebula-sdk/pkg/taskutil"
 	"github.com/spf13/cobra"
@@ -16,9 +14,10 @@ func NewGetCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path, _ := cmd.Flags().GetString("path")
 
-			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: taskutil.MetadataSpecURL()}
 			task := task.NewTaskInterface(planOpts)
 			data, err := task.ReadData(path)
+
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/git.go
+++ b/pkg/cmd/git.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/puppetlabs/nebula-sdk/pkg/task"
 	"github.com/puppetlabs/nebula-sdk/pkg/taskutil"
 	"github.com/spf13/cobra"
@@ -29,7 +27,7 @@ func NewGitCloneCommand() *cobra.Command {
 			directory, _ := cmd.Flags().GetString("directory")
 			revision, _ := cmd.Flags().GetString("revision")
 
-			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: taskutil.MetadataSpecURL()}
 			task := task.NewTaskInterface(planOpts)
 			return task.CloneRepository(revision, directory)
 		},

--- a/pkg/task/cluster_test.go
+++ b/pkg/task/cluster_test.go
@@ -28,7 +28,7 @@ func TestClusterOutput(t *testing.T) {
 	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
 		opts := taskutil.DefaultPlanOptions{
 			Client:  ts.Client(),
-			SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+			SpecURL: fmt.Sprintf("%s/spec", ts.URL),
 		}
 
 		task := NewTaskInterface(opts)

--- a/pkg/task/credentials_test.go
+++ b/pkg/task/credentials_test.go
@@ -30,7 +30,7 @@ func TestCredentialOutput(t *testing.T) {
 	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
 		opts := taskutil.DefaultPlanOptions{
 			Client:  ts.Client(),
-			SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+			SpecURL: fmt.Sprintf("%s/spec", ts.URL),
 		}
 
 		task := NewTaskInterface(opts)

--- a/pkg/task/file_test.go
+++ b/pkg/task/file_test.go
@@ -40,7 +40,7 @@ func TestGetFileOutput(t *testing.T) {
 	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
 		opts := taskutil.DefaultPlanOptions{
 			Client:  ts.Client(),
-			SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+			SpecURL: fmt.Sprintf("%s/spec", ts.URL),
 		}
 
 		task := NewTaskInterface(opts)

--- a/pkg/task/get.go
+++ b/pkg/task/get.go
@@ -1,10 +1,12 @@
 package task
 
 import (
-	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/puppetlabs/horsehead/v2/encoding/transfer"
 )
 
 func (ti *TaskInterface) ReadData(path string) ([]byte, error) {
@@ -39,12 +41,15 @@ func (ti *TaskInterface) ReadData(path string) ([]byte, error) {
 	}
 
 	var ret string
+	a := transfer.JSONInterface{}
+	_ = a.UnmarshalJSON(body)
 	if path != "" {
-		// If no path is specified, ni get returns the full json
-		err = json.Unmarshal(body, &ret)
+		// If a path is specified, `ni get` returns the single value, not json
+		ret = fmt.Sprintf("%s", a.Data)
 	} else {
-		// If a path is specified, ni get returns the single value
-		ret = string(body)
+		// If no path is specified, `ni get` returns the full encoded json
+		data, _ := a.MarshalJSON()
+		ret = string(data)
 	}
 
 	return []byte(ret), nil

--- a/pkg/task/get.go
+++ b/pkg/task/get.go
@@ -1,31 +1,51 @@
 package task
 
 import (
-	"context"
-
-	"github.com/puppetlabs/nebula-sdk/pkg/taskutil"
-	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/evaluate"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 )
 
 func (ti *TaskInterface) ReadData(path string) ([]byte, error) {
-	eval, err := taskutil.EvaluatorFromDefaultPlan(ti.opts)
+	u, err := url.Parse(ti.opts.SpecURL)
+	if err != nil {
+		return nil, err
+	}
+
+	q, err := url.ParseQuery(u.RawQuery)
 	if err != nil {
 		return nil, err
 	}
 
 	if path != "" {
-		output, _ := eval.EvaluateQuery(context.Background(), path)
-		switch vt := output.Value.(type) {
-		case string:
-			return []byte(vt), nil
-		}
-	} else {
-		eval := eval.Copy(evaluate.WithResultMapper(evaluate.NewJSONResultMapper()))
-		output, err := eval.EvaluateAll(context.Background())
-		if err == nil {
-			return output.Value.([]byte), nil
-		}
+		q.Add("q", path)
+		q.Add("lang", "jsonpath-template")
+
+		u.RawQuery = q.Encode()
 	}
 
-	return nil, nil
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, nil
+	}
+
+	var ret string
+	if path != "" {
+		// If no path is specified, ni get returns the full json
+		err = json.Unmarshal(body, &ret)
+	} else {
+		// If a path is specified, ni get returns the single value
+		ret = string(body)
+	}
+
+	return []byte(ret), nil
 }

--- a/pkg/task/get.go
+++ b/pkg/task/get.go
@@ -44,6 +44,10 @@ func (ti *TaskInterface) ReadData(path string) ([]byte, error) {
 		// Spec evaluation failed
 		return nil, nil
 	}
+	if resp.StatusCode/100 != 2 {
+		// This will be a non-200 code other than 404, 422, or 500
+		return nil, errors.New(fmt.Sprintf("an unexpected response %d was encountered when retrieving the spec", resp.StatusCode))
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/task/get_test.go
+++ b/pkg/task/get_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http/httptest"
 	"strconv"
@@ -47,5 +48,10 @@ func TestGetOutput(t *testing.T) {
 
 		output, _ = task.ReadData("{.data[1]}")
 		require.Equal(t, testSpec.Data[1], string(output))
+
+		output, _ = task.ReadData("")
+		var outputSpec *TestGetSpec
+		json.Unmarshal(output, &outputSpec)
+		require.Equal(t, testSpec, outputSpec)
 	}, opts)
 }

--- a/pkg/task/get_test.go
+++ b/pkg/task/get_test.go
@@ -45,7 +45,7 @@ func TestGetOutput(t *testing.T) {
 	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
 		opts := taskutil.DefaultPlanOptions{
 			Client:  ts.Client(),
-			SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+			SpecURL: fmt.Sprintf("%s/spec", ts.URL),
 		}
 
 		task := NewTaskInterface(opts)
@@ -65,12 +65,18 @@ func TestGetOutput(t *testing.T) {
 		output, _ = task.ReadData("{.data[2]}")
 		require.Equal(t, testSpec.Data[2], string(output))
 
+		output, err := task.ReadData("{.nothing}")
+		require.NoError(t, err)
+		require.Equal(t, "", string(output))
+
+		// Test the full spec
 		output, _ = task.ReadData("")
 		var outputSpec TestGetSpec
 		a := transfer.JSONInterface{}
-		_ = a.UnmarshalJSON(output)
+		err = a.UnmarshalJSON(output)
+		require.NoError(t, err)
 		e := evaluate.NewEvaluator()
-		_, err := e.EvaluateInto(context.Background(), a.Data, &outputSpec)
+		_, err = e.EvaluateInto(context.Background(), a.Data, &outputSpec)
 		require.NoError(t, err)
 		require.Equal(t, testSpec.Data[2], outputSpec.Data[2])
 

--- a/pkg/task/get_test.go
+++ b/pkg/task/get_test.go
@@ -1,14 +1,16 @@
 package task
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"strconv"
 	"testing"
 
+	"github.com/puppetlabs/horsehead/v2/encoding/transfer"
 	"github.com/puppetlabs/nebula-sdk/pkg/taskutil"
 	"github.com/puppetlabs/nebula-sdk/pkg/testutil"
+	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/evaluate"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,11 +24,22 @@ func TestGetOutput(t *testing.T) {
 	testSpec := &TestGetSpec{
 		Name:    "test1",
 		SomeNum: 12,
-		Data:    []string{"something", "else"},
+		Data:    []string{"something", "else", "Hello, \x90!"},
 	}
 
+	es := func(v ...string) (r []transfer.JSONOrStr) {
+		for i := range v {
+			a, _ := transfer.EncodeJSON([]byte(v[i]))
+			r = append(r, a)
+		}
+		return
+	}
 	opts := testutil.SingleSpecMockMetadataAPIOptions("test1", testutil.MockSpec{
-		ResponseObject: testSpec,
+		ResponseObject: map[string]interface{}{
+			"name":    "test1",
+			"someNum": 12,
+			"data":    es("something", "else", "Hello, \x90!"),
+		},
 	})
 
 	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
@@ -49,9 +62,17 @@ func TestGetOutput(t *testing.T) {
 		output, _ = task.ReadData("{.data[1]}")
 		require.Equal(t, testSpec.Data[1], string(output))
 
+		output, _ = task.ReadData("{.data[2]}")
+		require.Equal(t, testSpec.Data[2], string(output))
+
 		output, _ = task.ReadData("")
-		var outputSpec *TestGetSpec
-		json.Unmarshal(output, &outputSpec)
-		require.Equal(t, testSpec, outputSpec)
+		var outputSpec TestGetSpec
+		a := transfer.JSONInterface{}
+		_ = a.UnmarshalJSON(output)
+		e := evaluate.NewEvaluator()
+		_, err := e.EvaluateInto(context.Background(), a.Data, &outputSpec)
+		require.NoError(t, err)
+		require.Equal(t, testSpec.Data[2], outputSpec.Data[2])
+
 	}, opts)
 }

--- a/pkg/taskutil/spec.go
+++ b/pkg/taskutil/spec.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
+	"path"
 
 	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/evaluate"
 	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/parse"
@@ -92,7 +92,7 @@ type DefaultPlanOptions struct {
 
 func MetadataSpecURL() string {
 	if u := os.Getenv(MetadataAPIURLEnvName); u != "" {
-		return strings.Join([]string{strings.TrimSuffix(u, "/"), "spec"}, "/")
+		return path.Join(u, "spec")
 	}
 	return ""
 }

--- a/pkg/taskutil/spec.go
+++ b/pkg/taskutil/spec.go
@@ -10,12 +10,13 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/evaluate"
 	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/parse"
 )
 
-const SpecURLEnvName = "SPEC_URL"
+const MetadataAPIURLEnvName = "METADATA_API_URL"
 
 // SpecLoader returns an io.Reader containing the bytes
 // of a task spec. This is used as input to a spec unmarshaler.
@@ -89,15 +90,25 @@ type DefaultPlanOptions struct {
 	SpecURL string
 }
 
+func MetadataSpecURL() string {
+	if u := os.Getenv(MetadataAPIURLEnvName); u != "" {
+		return strings.Join([]string{strings.TrimSuffix(u, "/"), "spec"}, "/")
+	}
+	return ""
+}
+
 func PopulateSpecFromDefaultPlan(target interface{}, opts DefaultPlanOptions) error {
 	eval, err := EvaluatorFromDefaultPlan(opts)
 	if err != nil {
 		return err
 	}
 
+	resultTarget := evaluate.Result{
+		Value: target,
+	}
 	// The existing behavior is to substitute empty strings where secrets,
 	// outputs, etc. are currently missing. We should revisit this.
-	_, err = eval.EvaluateInto(context.Background(), &target)
+	_, err = eval.EvaluateInto(context.Background(), &resultTarget)
 	if err != nil {
 		return err
 	}
@@ -109,15 +120,15 @@ func EvaluatorFromDefaultPlan(opts DefaultPlanOptions) (*evaluate.ScopedEvaluato
 	location := opts.SpecURL
 
 	if location == "" {
-		location := os.Getenv(SpecURLEnvName)
+		location = MetadataSpecURL()
 		if location == "" {
-			return nil, errors.New("SPEC_URL was empty")
+			return nil, errors.New(fmt.Sprintf("%s was empty", MetadataAPIURLEnvName))
 		}
 	}
 
 	u, err := url.Parse(location)
 	if err != nil {
-		return nil, fmt.Errorf("parsing SPEC_URL failed: %+v", err)
+		return nil, fmt.Errorf("parsing spec URL %s failed: %+v", location, err)
 	}
 
 	var loader SpecLoader

--- a/pkg/taskutil/spec.go
+++ b/pkg/taskutil/spec.go
@@ -123,12 +123,6 @@ func EvaluatorFromDefaultPlan(opts DefaultPlanOptions) (*evaluate.ScopedEvaluato
 	var loader SpecLoader
 
 	switch u.Scheme {
-	case "file":
-		if u.Host != "" {
-			return nil, errors.New("unable to read from remote host in file URL")
-		}
-
-		loader = NewLocalSpecLoader(u.Path)
 	case "http", "https":
 		loader = NewRemoteSpecLoader(u, opts.Client)
 	default:

--- a/pkg/taskutil/spec_test.go
+++ b/pkg/taskutil/spec_test.go
@@ -35,7 +35,7 @@ func TestDefaultSpecPlan(t *testing.T) {
 
 		opts := DefaultPlanOptions{
 			Client:  ts.Client(),
-			SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+			SpecURL: fmt.Sprintf("%s/spec", ts.URL),
 		}
 
 		require.NoError(t, PopulateSpecFromDefaultPlan(&testSpec, opts))


### PR DESCRIPTION
Previously `ni get` depended on specific endpoints such as `/api/secrets` to resolve queries of the step spec locally as part of the `EvaluateQuery` and `EvaluateAll` calls.

This PR replaces that with a single http call (intended for `/api/spec` or `/api/specs/:id` as already defined by `SPEC_URL`) that passes the spec query string to the metadata api and lets the server-side logic do value resolution. Essentially the `EvaluateQuery` and `EvaluateAll` calls should be server-side only.