### PR TITLE
Add webhook server with sensible defaults and ability to run WSGI/ASGI applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Add: Support emitting events in the Python SDK.
+* Add: Provide a simple HTTP server preconfigured for our webhook environment
+  that can run WSGI and ASGI applications.
 
 ## [1.12.4]
 

--- a/support/python/setup.py
+++ b/support/python/setup.py
@@ -17,6 +17,8 @@ setuptools.setup(
         'setuptools_scm',
     ],
     install_requires=[
+        'asgiref>=3.2.7',
+        'hypercorn>=0.9.5',
         'requests>=2.23',
     ],
     classifiers=[

--- a/support/python/src/nebula_sdk/__init__.py
+++ b/support/python/src/nebula_sdk/__init__.py
@@ -1,3 +1,15 @@
 from .interface import Dynamic, Interface, UnresolvableException
+from .util import (NoTerminationPolicy, SignalTerminationPolicy,
+                   SoftTerminationPolicy, TerminationPolicy)
+from .webhook import WebhookServer
 
-__all__ = ['Dynamic', 'Interface', 'UnresolvableException']
+__all__ = [
+    'Dynamic',
+    'Interface',
+    'UnresolvableException',
+    'NoTerminationPolicy',
+    'SignalTerminationPolicy',
+    'SoftTerminationPolicy',
+    'TerminationPolicy',
+    'WebhookServer',
+]

--- a/support/python/src/nebula_sdk/util.py
+++ b/support/python/src/nebula_sdk/util.py
@@ -1,8 +1,12 @@
+import asyncio
 import base64
 import datetime
 import functools
+import inspect
 import json
-from typing import Any, Callable, Mapping, Union
+import signal
+from typing import (Any, Awaitable, Callable, Iterable, Mapping, Optional,
+                    Protocol, Union)
 
 
 def json_object_hook(dct: Mapping[str, Any]) -> Any:
@@ -47,3 +51,84 @@ class JSONEncoder(json.JSONEncoder):
                 '$encoding': 'base64',
                 'data': base64.standard_b64encode(obj),
             }
+
+
+def is_async_callable(obj: Any) -> bool:
+    if not callable(obj):
+        return False
+
+    return (
+        inspect.iscoroutinefunction(obj) or
+        inspect.iscoroutinefunction(obj.__call__)
+    )
+
+
+class TerminationPolicy(Protocol):
+
+    def apply(self) -> Optional[Callable[..., Awaitable[None]]]: ...
+
+
+class NoTerminationPolicy(TerminationPolicy):
+
+    def apply(self) -> Optional[Callable[..., Awaitable[None]]]:
+        return None
+
+
+class SoftTerminationPolicy(TerminationPolicy):
+
+    _event: asyncio.Event
+    _timeout_sec: Optional[float]
+
+    def __init__(self, *, timeout_sec: Optional[float] = None):
+        self._event = asyncio.Event()
+        self._timeout_sec = timeout_sec
+
+    async def terminate(self) -> None:
+        self._event.set()
+
+        termination_task = asyncio.current_task()
+        other_tasks = asyncio.gather(*filter(
+            lambda t: t != termination_task,
+            asyncio.all_tasks(),
+        ), return_exceptions=True)
+
+        if self._timeout_sec is not None:
+            try:
+                await asyncio.wait_for(other_tasks, self._timeout_sec)
+            except asyncio.TimeoutError:
+                other_tasks.cancel()
+
+        await other_tasks
+
+    def apply(self) -> Optional[Callable[..., Awaitable[None]]]:
+        async def wait() -> None:
+            await self._event.wait()
+
+        return wait
+
+
+class SignalTerminationPolicy(TerminationPolicy):
+
+    _signals: Iterable[signal.Signals]
+    _delegate: SoftTerminationPolicy
+
+    def __init__(self, *,
+                 signals: Optional[Iterable[signal.Signals]] = None,
+                 timeout_sec: Optional[float] = None):
+        if signals is None:
+            signals = [signal.SIGINT, signal.SIGTERM]
+
+        self._signals = signals
+        self._delegate = SoftTerminationPolicy(timeout_sec=timeout_sec)
+
+    def apply(self) -> Optional[Callable[..., Awaitable[None]]]:
+        loop = asyncio.get_event_loop()
+        wait = self._delegate.apply()
+
+        for sig in self._signals:
+            loop.add_signal_handler(
+                sig,
+                lambda: loop.create_task(self._delegate.terminate()),
+            )
+
+        return wait

--- a/support/python/src/nebula_sdk/webhook.py
+++ b/support/python/src/nebula_sdk/webhook.py
@@ -1,0 +1,65 @@
+import asyncio
+import os
+from typing import TYPE_CHECKING, Optional, Union, cast
+
+from asgiref.wsgi import WsgiToAsgi
+from hypercorn.asyncio.run import worker_serve
+from hypercorn.config import Config, Sockets
+from hypercorn.typing import ASGIFramework
+
+from .util import SignalTerminationPolicy, TerminationPolicy, is_async_callable
+
+if TYPE_CHECKING:
+    from wsgiref.types import WSGIApplication
+
+DEFAULT_TERMINATION_POLICY = SignalTerminationPolicy(timeout_sec=25)
+DEFAULT_PORT = 8080
+
+
+class PortParseError(Exception):
+    pass
+
+
+class WebhookServer:
+
+    _app: ASGIFramework
+    _config: Config
+    _sockets: Sockets
+    _termination_policy: TerminationPolicy
+
+    def __init__(self, app: Union[ASGIFramework, 'WSGIApplication'], *,
+                 termination_policy: Optional[TerminationPolicy] = None,
+                 port: Optional[int] = None):
+        if not is_async_callable(app):
+            app = WsgiToAsgi(app)
+
+        if termination_policy is None:
+            termination_policy = DEFAULT_TERMINATION_POLICY
+
+        if port is None:
+            try:
+                port = int(os.environ['PORT'])
+            except KeyError:
+                port = DEFAULT_PORT
+            except ValueError:
+                raise PortParseError()
+
+        self._app = cast(ASGIFramework, app)
+        self._config = Config()
+        self._config.bind = [f'0.0.0.0:{port}']
+        self._sockets = self._config.create_sockets()
+        self._termination_policy = termination_policy
+
+    @property
+    def port(self) -> int:
+        return self._sockets.insecure_sockets[0].getsockname()[1]
+
+    async def serve(self) -> None:
+        shutdown_trigger = self._termination_policy.apply()
+
+        await worker_serve(self._app, self._config,
+                           sockets=self._sockets,
+                           shutdown_trigger=shutdown_trigger)
+
+    def serve_forever(self) -> None:
+        asyncio.run(self.serve())

--- a/support/python/tests/conftest.py
+++ b/support/python/tests/conftest.py
@@ -1,0 +1,21 @@
+import asyncio
+from typing import Any, Dict, Iterable
+
+import pytest
+
+
+def event_loop_exception_handler(loop: asyncio.AbstractEventLoop,
+                                 context: Dict[str, Any]) -> None:
+    # Ignore dropped tasks in test.
+    if loop.is_closed() and isinstance(context.get('task'), asyncio.Task):
+        return
+
+    loop.default_exception_handler(context)
+
+
+@pytest.fixture
+def event_loop() -> Iterable[asyncio.AbstractEventLoop]:
+    loop = asyncio.new_event_loop()
+    loop.set_exception_handler(event_loop_exception_handler)
+    yield loop
+    loop.close()

--- a/support/python/tests/test_util.py
+++ b/support/python/tests/test_util.py
@@ -1,9 +1,12 @@
+import asyncio
 import datetime
 import json
+import signal
 from typing import Any
 
 import pytest
-from nebula_sdk.util import JSONEncoder, json_object_hook
+from nebula_sdk.util import (JSONEncoder, SignalTerminationPolicy,
+                             is_async_callable, json_object_hook)
 
 
 @pytest.mark.parametrize(
@@ -29,3 +32,79 @@ def test_json_decoding() -> None:
         r'{"$encoding": "base64", "data": "kA=="}',
         object_hook=json_object_hook,
     ) == b'\x90'
+
+
+def test_is_async_callable() -> None:
+    class AsyncCallable:
+
+        async def __call__(self) -> None:
+            pass
+
+    class Callable:
+
+        def __call__(self) -> None:
+            pass
+
+    async def async_callable() -> None:
+        pass
+
+    def sync_callable() -> None:
+        pass
+
+    assert is_async_callable(AsyncCallable())
+    assert is_async_callable(async_callable)
+    assert not is_async_callable(Callable)
+    assert not is_async_callable(sync_callable)
+    assert not is_async_callable(2)
+
+
+class TestSignalTerminationPolicy:
+
+    @pytest.mark.asyncio
+    async def test_indefinite(self) -> None:
+        pol = SignalTerminationPolicy(signals=[signal.SIGWINCH])
+
+        ready_event = asyncio.Event()
+        completion_event = asyncio.Event()
+
+        async def run() -> None:
+            waiter = pol.apply()
+            assert waiter is not None
+            ready_event.set()
+
+            await waiter()
+            completion_event.set()
+
+        async def raise_signal() -> None:
+            await ready_event.wait()
+            signal.raise_signal(signal.SIGWINCH)
+
+        await asyncio.gather(run(), raise_signal())
+        await asyncio.wait_for(completion_event.wait(), 60)
+
+    @pytest.mark.asyncio
+    async def test_timeout(self) -> None:
+        pol = SignalTerminationPolicy(
+            signals=[signal.SIGWINCH],
+            timeout_sec=0,  # Immediate timeout.
+        )
+
+        ready_event = asyncio.Event()
+
+        async def run() -> None:
+            waiter = pol.apply()
+            assert waiter is not None
+            ready_event.set()
+
+            await waiter()
+
+            # Instead of completing we'll force the policy to terminate us
+            # early.
+            await asyncio.sleep(30)
+
+        async def raise_signal() -> None:
+            await ready_event.wait()
+            signal.raise_signal(signal.SIGWINCH)
+
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.gather(run(), raise_signal())

--- a/support/python/tests/test_webhook.py
+++ b/support/python/tests/test_webhook.py
@@ -1,0 +1,136 @@
+import asyncio
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Mapping
+
+import pytest
+from nebula_sdk.util import SoftTerminationPolicy
+from nebula_sdk.webhook import WebhookServer
+from quart import Quart
+from requests import Session
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+if TYPE_CHECKING:
+    from wsgiref.types import StartResponse
+
+
+retry_strategy = Retry(
+    total=4,
+    backoff_factor=1,
+)
+
+session = Session()
+session.mount('http://', HTTPAdapter(max_retries=retry_strategy))
+
+
+class TestWebhookServer:
+
+    @pytest.mark.asyncio
+    async def test_asgi_2(self, event_loop: asyncio.AbstractEventLoop) -> None:
+        class Application:
+
+            def __init__(self, scope: Dict[Any, Any]) -> None:
+                if scope['type'] != 'http':
+                    raise NotImplementedError()
+
+            async def __call__(self, receive: Callable[..., Any],
+                               send: Callable[..., Any]) -> None:
+                await send({
+                    'type': 'http.response.start',
+                    'status': 200,
+                })
+                await send({
+                    'type': 'http.response.body',
+                    'body': b'{"success": true}'
+                })
+
+        term = SoftTerminationPolicy()
+
+        srv = WebhookServer(Application, termination_policy=term, port=0)
+        event_loop.create_task(srv.serve())
+
+        resp = await event_loop.run_in_executor(
+            None, session.get,
+            f'http://localhost:{srv.port}',
+        )
+        resp.raise_for_status()
+
+        assert resp.json() == {'success': True}
+
+        await term.terminate()
+
+    @pytest.mark.asyncio
+    async def test_asgi_3(self, event_loop: asyncio.AbstractEventLoop) -> None:
+        async def application(scope: Dict[Any, Any],
+                              receive: Callable[..., Any],
+                              send: Callable[..., Any]) -> None:
+            if scope['type'] != 'http':
+                raise NotImplementedError()
+
+            await send({
+                'type': 'http.response.start',
+                'status': 200,
+            })
+            await send({
+                'type': 'http.response.body',
+                'body': b'{"success": true}'
+            })
+
+        term = SoftTerminationPolicy()
+
+        srv = WebhookServer(application, termination_policy=term, port=0)
+        event_loop.create_task(srv.serve())
+
+        resp = await event_loop.run_in_executor(
+            None, session.get,
+            f'http://localhost:{srv.port}',
+        )
+        resp.raise_for_status()
+
+        assert resp.json() == {'success': True}
+
+        await term.terminate()
+
+    @pytest.mark.asyncio
+    async def test_wsgi(self, event_loop: asyncio.AbstractEventLoop) -> None:
+        def application(environ: Mapping[str, Any],
+                        start_response: 'StartResponse') -> Iterable[bytes]:
+            start_response('200 OK', [])
+            yield b'{"success": true}'
+
+        term = SoftTerminationPolicy()
+
+        srv = WebhookServer(application, termination_policy=term, port=0)
+        event_loop.create_task(srv.serve())
+
+        resp = await event_loop.run_in_executor(
+            None, session.get,
+            f'http://localhost:{srv.port}',
+        )
+        resp.raise_for_status()
+
+        assert resp.json() == {'success': True}
+
+        await term.terminate()
+
+    @pytest.mark.asyncio
+    async def test_quart(self, event_loop: asyncio.AbstractEventLoop) -> None:
+        application = Quart(__name__)
+
+        @application.route('/')
+        async def hello() -> str:
+            return '{"success": true}'
+
+        term = SoftTerminationPolicy()
+
+        srv = WebhookServer(application, termination_policy=term, port=0)
+        event_loop.create_task(srv.serve())
+
+        resp = await event_loop.run_in_executor(
+            None, session.get,
+            f'http://localhost:{srv.port}',
+        )
+        resp.raise_for_status()
+
+        assert resp.json() == {'success': True}
+
+        await term.terminate()

--- a/support/python/tox.ini
+++ b/support/python/tox.ini
@@ -3,23 +3,28 @@ envlist = py38
 isolated_build = True
 distshare = {toxinidir}/dist
 
-[testenv]
+[base]
 deps =
     pytest
-    pytest-cov
+    quart
     requests-mock
+
+[testenv]
+deps =
+    {[base]deps}
+    pytest-asyncio
+    pytest-cov
 commands =
-    {posargs:pytest --cov=nebula_sdk --cov-report=term-missing -vv tests}
+    pytest --cov=nebula_sdk --cov-report=term-missing {posargs:-vv} tests
 
 [testenv:check]
 basepython = python3.8
 deps =
+    {[base]deps}
     check-manifest
     flake8
     isort
     mypy
-    pytest
-    requests-mock
 ignore_errors = true
 commands =
     check-manifest {toxinidir}


### PR DESCRIPTION
Example (off the top of my head, so don't hold me to this if it has syntax errors):

```python
from nebula_sdk import Interface, WebhookServer
from quart import Quart, request

relay = Interface()
app = Quart('pagerduty')

@app.route('/', methods=['POST'])
async def webhook():
  data = await request.get_json()
  relay.events.emit(data)
  return {'success': True}

if __name__ == '__main__':
  WebhookServer(app).serve_forever()
```