### PR TITLE
Adds cleaner ni doc command

### DIFF
--- a/docs/generate.go
+++ b/docs/generate.go
@@ -1,0 +1,3 @@
+package docs
+
+//go:generate go run ../cmd/ni doc -f ni.md

--- a/docs/ni.md
+++ b/docs/ni.md
@@ -1,0 +1,80 @@
+## ni
+
+Nebula Interface
+
+### Synopsis
+
+The ni tool is meant to be run inside a Relay (FKA "Nebula")
+step container to provide helpful SDK-like utilities from the shell.
+Invoke it from your relay steps to access parameters and secrets,
+generate logs that will be stored on the service, and pass data
+between steps.
+
+
+### Subcommand Usage
+
+**`ni aws config`** -- Create an AWS configuration suitable for using with an AWS CLI or SDK
+```
+  -d, --directory string   configuration output directory
+```
+
+**`ni aws env`** -- Create a POSIX-compatible script that can be sourced to configure the AWS CLI
+```
+  -d, --directory string   configuration output directory
+```
+
+**`ni cluster config`** -- Create cluster config
+```
+  -d, --directory string   configuration output directory
+```
+
+**`ni credentials config`** -- Create credentials configuration
+```
+  -d, --directory string   configuration output directory
+```
+
+**`ni doc [flags]`** -- build command documentation
+```
+  -f, --file string   The path to a file to write the documentation to
+```
+
+**`ni file`** -- WriteFile specification data to a file
+```
+  -f, --file string     file name
+  -o, --output string   output type
+  -p, --path string     specification data path
+```
+
+**`ni get`** -- Get specification data
+```
+  -p, --path string   specification data path
+```
+
+**`ni git clone`** -- Clone git repository
+```
+  -d, --directory string   git clone output directory
+  -r, --revision string    git revision
+```
+
+**`ni log error`** -- Logs an error message
+
+**`ni log fatal`** -- Logs a fatal error message and exits process
+
+**`ni log info`** -- Logs an informational message
+
+**`ni log warn`** -- Logs a warning message
+
+**`ni output get`** -- Get a value that a previous task stored
+```
+      --json               whether to always provide the output as JSON, even if it is a string
+  -k, --key string         the output key
+  -n, --task-name string   the name of the task
+```
+
+**`ni output set`** -- Set a value to a key that can be fetched by another task
+```
+      --json           whether the value should be interpreted as a JSON string
+  -k, --key string     the output key
+  -v, --value string   the output value
+```
+

--- a/pkg/cmd/doc.go
+++ b/pkg/cmd/doc.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+// NewDocCommand adds the 'doc' subcommand under the root 'ni'
+func NewDocCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "doc",
+		Short: "build command documentation",
+		Args:  cobra.MinimumNArgs(1),
+	}
+
+	cmd.AddCommand(newGenerateCommand())
+
+	return cmd
+}
+
+func newGenerateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate documentation",
+		Args:  cobra.NoArgs,
+		RunE:  genDocs,
+	}
+
+	cmd.Flags().StringP("target", "t", "./docs/", "target directory for output")
+
+	return cmd
+}
+
+func genDocs(cmd *cobra.Command, args []string) error {
+	targetDir, nil := cmd.Flags().GetString("target")
+
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		cmd.Printf(`Failed to create target directory %s: %s`, targetDir, err.Error())
+		return err
+	}
+
+	rootcmd, nil := NewRootCommand()
+
+	doc.GenMarkdownTree(rootcmd, targetDir)
+
+	return nil
+
+}

--- a/pkg/cmd/doc.go
+++ b/pkg/cmd/doc.go
@@ -1,9 +1,8 @@
-// go:generate go run generate_docs.go
-
 package cmd
 
 import (
 	"bytes"
+	"io/ioutil"
 
 	"github.com/spf13/cobra"
 )
@@ -16,6 +15,8 @@ func NewDocCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  genDocs,
 	}
+
+	cmd.Flags().StringP("file", "f", "", "The path to a file to write the documentation to")
 
 	return cmd
 }
@@ -51,7 +52,13 @@ func genDocs(cmd *cobra.Command, args []string) error {
 		buf.WriteString("### Global flags\n```\n")
 		buf.WriteString(flags.FlagUsages() + "\n```\n")
 	}
-	rootcmd.OutOrStdout().Write(buf.Bytes())
+
+	file, nil := cmd.Flags().GetString("file")
+	if file == "" {
+		cmd.OutOrStdout().Write(buf.Bytes())
+	} else if err := ioutil.WriteFile(file, buf.Bytes(), 0644); err != nil {
+		return err
+	}
 
 	return nil
 

--- a/pkg/cmd/doc.go
+++ b/pkg/cmd/doc.go
@@ -1,10 +1,11 @@
+// go:generate go run generate_docs.go
+
 package cmd
 
 import (
-	"os"
+	"bytes"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
 )
 
 // NewDocCommand adds the 'doc' subcommand under the root 'ni'
@@ -12,38 +13,80 @@ func NewDocCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "doc",
 		Short: "build command documentation",
-		Args:  cobra.MinimumNArgs(1),
-	}
-
-	cmd.AddCommand(newGenerateCommand())
-
-	return cmd
-}
-
-func newGenerateCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "generate",
-		Short: "Generate documentation",
 		Args:  cobra.NoArgs,
 		RunE:  genDocs,
 	}
-
-	cmd.Flags().StringP("target", "t", "./docs/", "target directory for output")
 
 	return cmd
 }
 
 func genDocs(cmd *cobra.Command, args []string) error {
-	targetDir, nil := cmd.Flags().GetString("target")
+	buf := new(bytes.Buffer)
+	rootcmd, err := NewRootCommand()
 
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		cmd.Printf(`Failed to create target directory %s: %s`, targetDir, err.Error())
+	if err != nil {
 		return err
 	}
 
-	rootcmd, nil := NewRootCommand()
+	rootcmd.InitDefaultHelpCmd()
+	rootcmd.InitDefaultHelpFlag()
 
-	doc.GenMarkdownTree(rootcmd, targetDir)
+	name := rootcmd.CommandPath()
+
+	short := rootcmd.Short
+	long := rootcmd.Long
+
+	buf.WriteString("## " + name + "\n\n" + short + "\n\n")
+	buf.WriteString("### Synopsis\n\n" + long + "\n\n")
+	buf.WriteString("### Subcommand Usage\n\n")
+
+	children := rootcmd.Commands()
+
+	if err := genChildMarkdown(children, buf); err != nil {
+		return err
+	}
+
+	flags := rootcmd.PersistentFlags()
+	if flags.HasAvailableFlags() {
+		buf.WriteString("### Global flags\n```\n")
+		buf.WriteString(flags.FlagUsages() + "\n```\n")
+	}
+	rootcmd.OutOrStdout().Write(buf.Bytes())
+
+	return nil
+
+}
+
+// For brevity, we only want to generate docs for 'leaf' commands, i.e.
+// only "ni output get", not "ni output"
+func genChildMarkdown(children []*cobra.Command, buf *bytes.Buffer) error {
+
+	for _, child := range children {
+		if !child.IsAvailableCommand() || child.IsAdditionalHelpTopicCommand() {
+			continue
+		}
+		if child.Runnable() {
+			usage := child.UseLine()
+			buf.WriteString("**`" + usage + "`** -- " + child.Short + "\n")
+			long := child.Long
+			if len(long) > 0 {
+				buf.WriteString("  " + child.Long + "\n")
+			}
+			flags := child.NonInheritedFlags()
+			if flags.HasAvailableFlags() {
+				buf.WriteString("```\n")
+				flags.SetOutput(buf)
+				flags.PrintDefaults()
+				buf.WriteString("```\n")
+			}
+			buf.WriteString("\n")
+		}
+		// Because commands can be nested arbitrarily deep, this recurses into
+		// the current command's children and generates their docs too
+		grandchildren := child.Commands()
+		genChildMarkdown(grandchildren, buf)
+
+	}
 
 	return nil
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -10,6 +10,12 @@ func NewRootCommand() (*cobra.Command, error) {
 		Short:         "Nebula Interface",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		Long: `The ni tool is meant to be run inside a Relay (FKA "Nebula")
+step container to provide helpful SDK-like utilities from the shell.
+Invoke it from your relay steps to access parameters and secrets,
+generate logs that will be stored on the service, and pass data
+between steps.
+`,
 	}
 
 	c.AddCommand(NewClusterCommand())

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -20,6 +20,7 @@ func NewRootCommand() (*cobra.Command, error) {
 	c.AddCommand(NewAWSCommand())
 	c.AddCommand(NewOutputCommand())
 	c.AddCommand(NewLogCommand())
+	c.AddCommand(NewDocCommand())
 
 	return c, nil
 }


### PR DESCRIPTION
This adds a `ni doc` subcommand that generates a single page of markdown
with all the 'leaf' commands included.