### PR TITLE
Initial support for handling markdown conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20200513213024-62c5e2c608cc
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/imdario/mergo v0.3.8
 	github.com/jedib0t/go-pretty v4.3.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/gomarkdown/markdown v0.0.0-20200513213024-62c5e2c608cc h1:T+Fwk3llJdUIQeBI8fC/ARqRD5mWy3AE5I6ZU3VkIw8=
+github.com/gomarkdown/markdown v0.0.0-20200513213024-62c5e2c608cc/go.mod h1:aii0r/K0ZnHv7G0KF7xy1v0A7s2Ljrb5byB7MO5p6TU=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -177,6 +179,7 @@ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQ
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.mongodb.org/mongo-driver v1.0.3 h1:GKoji1ld3tw2aC+GX1wbr/J2fX13yNacEYoJ8Nhr0yU=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
+golang.org/dl v0.0.0-20190829154251-82a15e2f2ead/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=

--- a/pkg/workflow/spec/convert/convert.go
+++ b/pkg/workflow/spec/convert/convert.go
@@ -21,7 +21,7 @@ const (
 func ConvertMarkdown(ct ConvertType, md []byte) ([]byte, error) {
 	doc := markdown.Parse(md, nil)
 
-	renderer, err := NewRenderer(ct)
+	renderer, err := NewMarkdownRenderer(ct)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +29,7 @@ func ConvertMarkdown(ct ConvertType, md []byte) ([]byte, error) {
 	return markdown.Render(doc, renderer), nil
 }
 
-func NewRenderer(ct ConvertType) (markdown.Renderer, error) {
+func NewMarkdownRenderer(ct ConvertType) (markdown.Renderer, error) {
 	switch ct {
 	case ConvertTypeHtml:
 		opts := html.RendererOptions{

--- a/pkg/workflow/spec/convert/convert.go
+++ b/pkg/workflow/spec/convert/convert.go
@@ -1,0 +1,45 @@
+package convert
+
+import (
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/html"
+	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/convert/render/jira"
+)
+
+type ConvertType string
+
+func (ct ConvertType) String() string {
+	return string(ct)
+}
+
+const (
+	ConvertTypeHtml  ConvertType = "html"
+	ConvertTypeJira  ConvertType = "jira"
+	ConvertTypeSlack ConvertType = "slack"
+)
+
+func ConvertMarkdown(ct ConvertType, md []byte) ([]byte, error) {
+	doc := markdown.Parse(md, nil)
+
+	renderer, err := NewRenderer(ct)
+	if err != nil {
+		return nil, err
+	}
+
+	return markdown.Render(doc, renderer), nil
+}
+
+func NewRenderer(ct ConvertType) (markdown.Renderer, error) {
+	switch ct {
+	case ConvertTypeHtml:
+		opts := html.RendererOptions{
+			Flags: html.CommonFlags,
+		}
+		return html.NewRenderer(opts), nil
+	case ConvertTypeJira:
+		opts := jira.RendererOptions{}
+		return jira.NewRenderer(opts), nil
+	default:
+		return nil, ErrConvertTypeNotSupported
+	}
+}

--- a/pkg/workflow/spec/convert/errors.go
+++ b/pkg/workflow/spec/convert/errors.go
@@ -1,0 +1,9 @@
+package convert
+
+import (
+	"errors"
+)
+
+var (
+	ErrConvertTypeNotSupported = errors.New("convert: type not supported")
+)

--- a/pkg/workflow/spec/convert/render/jira/render.go
+++ b/pkg/workflow/spec/convert/render/jira/render.go
@@ -57,7 +57,7 @@ func (r *Renderer) text(w io.Writer, text *ast.Text) {
 		r := regexp.MustCompile("(^|\\s+)(-\\s*-\\s*-)(\\s+|$)")
 		md := r.ReplaceAllString(string(text.Literal), "\n----\n")
 		md = strings.TrimPrefix(md, "%%% ")
-		md = strings.TrimSuffix(md, " %%%")
+		md =strings.TrimSuffix(md, " %%%")
 
 		w.Write([]byte(md))
 	}

--- a/pkg/workflow/spec/convert/render/jira/render.go
+++ b/pkg/workflow/spec/convert/render/jira/render.go
@@ -1,0 +1,103 @@
+package jira
+
+import (
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/gomarkdown/markdown/ast"
+)
+
+type RendererOptions struct {
+}
+
+type Renderer struct {
+}
+
+func NewRenderer(opts RendererOptions) *Renderer {
+	return nil
+}
+
+func (r *Renderer) RenderHeader(w io.Writer, ast ast.Node) {}
+
+func (r *Renderer) RenderFooter(w io.Writer, ast ast.Node) {}
+
+func (r *Renderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.WalkStatus {
+	switch node := node.(type) {
+	case *ast.Code:
+		r.code(w, node)
+	case *ast.Image:
+		r.image(w, node, entering)
+	case *ast.Link:
+		r.link(w, node, entering)
+	case *ast.Text:
+		r.text(w, node)
+	}
+	return ast.GoToNext
+}
+
+func (r *Renderer) code(w io.Writer, code *ast.Code) {
+	io.WriteString(w, "{code}")
+	w.Write(code.Literal)
+	io.WriteString(w, "{code}")
+}
+
+func (r *Renderer) text(w io.Writer, text *ast.Text) {
+	switch text.Parent.(type) {
+	case *ast.Link:
+		if string(text.Literal) != "" {
+			io.WriteString(w, "[")
+			w.Write(text.Literal)
+		}
+	case *ast.Image:
+		io.WriteString(w, "\n\n")
+		break
+	default:
+		// TODO These are specific workarounds that will need better handling
+		r := regexp.MustCompile("(^|\\s+)(-\\s*-\\s*-)(\\s+|$)")
+		md := r.ReplaceAllString(string(text.Literal), "\n----\n")
+		md = strings.TrimPrefix(md, "%%% ")
+		md = strings.TrimSuffix(md, " %%%")
+
+		w.Write([]byte(md))
+	}
+}
+
+func (r *Renderer) link(w io.Writer, link *ast.Link, entering bool) {
+	if entering {
+		r.linkEnter(w, link)
+	} else {
+		r.linkExit(w, link)
+	}
+}
+
+func (r *Renderer) linkEnter(w io.Writer, link *ast.Link) {
+}
+
+func (r *Renderer) linkExit(w io.Writer, link *ast.Link) {
+	io.WriteString(w, "|")
+	w.Write(link.Destination)
+	io.WriteString(w, "]")
+}
+
+func (r *Renderer) image(w io.Writer, image *ast.Image, entering bool) {
+	if entering {
+		r.imageEnter(w, image)
+	} else {
+		r.imageExit(w, image)
+	}
+}
+
+func (r *Renderer) imageEnter(w io.Writer, image *ast.Image) {
+}
+
+func (r *Renderer) imageExit(w io.Writer, image *ast.Image) {
+	switch image.Parent.(type) {
+	case *ast.Link:
+		io.WriteString(w, "[")
+	}
+
+	io.WriteString(w, "!")
+	w.Write(image.Destination)
+	io.WriteString(w, "!")
+}

--- a/pkg/workflow/spec/evaluate/evaluate_test.go
+++ b/pkg/workflow/spec/evaluate/evaluate_test.go
@@ -502,6 +502,20 @@ func TestEvaluate(t *testing.T) {
 			},
 		},
 		{
+			Name: "successful invocation of fn.convertMarkdown to Jira syntax",
+			Data: `{
+				"foo": {
+					"$fn.convertMarkdown": [
+						"jira",` +
+				"\"--- `code` ---\"" + `
+					]
+				}
+			}`,
+			ExpectedValue: map[string]interface{}{
+				"foo": "\n----\n{code}code{code}\n----\n",
+			},
+		},
+		{
 			Name: "unresolved conditionals evaluation",
 			Data: `{
 				"conditions": [{"$fn.equals": [

--- a/pkg/workflow/spec/fnlib/convert.go
+++ b/pkg/workflow/spec/fnlib/convert.go
@@ -11,13 +11,13 @@ import (
 var convertMarkdownDescriptor = fn.DescriptorFuncs{
 	DescriptionFunc: func() string { return "Converts a string in markdown format to another applicable syntax" },
 	PositionalInvokerFunc: func(args []interface{}) (fn.Invoker, error) {
-		fn := fn.InvokerFunc(func(ctx context.Context) (m interface{}, err error) {
-			if len(args) != 2 {
-				return nil, &fn.ArityError{Wanted: []int{2}, Variadic: true, Got: len(args)}
-			}
+		if len(args) != 2 {
+			return nil, &fn.ArityError{Wanted: []int{2}, Variadic: false, Got: len(args)}
+		}
 
-			convertType, ok := args[0].(string)
-			if !ok {
+		fn := fn.InvokerFunc(func(ctx context.Context) (m interface{}, err error) {
+			to, found := args[0].(string)
+			if !found {
 				return nil, &fn.PositionalArgError{
 					Arg: 0,
 					Cause: &fn.UnexpectedTypeError{
@@ -27,9 +27,9 @@ var convertMarkdownDescriptor = fn.DescriptorFuncs{
 				}
 			}
 
-			switch arg := args[1].(type) {
+			switch md := args[1].(type) {
 			case string:
-				r, err := convert.ConvertMarkdown(convert.ConvertType(convertType), []byte(arg))
+				r, err := convert.ConvertMarkdown(convert.ConvertType(to), []byte(md))
 				if err != nil {
 					return nil, err
 				}
@@ -45,5 +45,46 @@ var convertMarkdownDescriptor = fn.DescriptorFuncs{
 			}
 		})
 		return fn, nil
+	},
+	KeywordInvokerFunc: func(args map[string]interface{}) (fn.Invoker, error) {
+		to, found := args["to"]
+		if !found {
+			return nil, &fn.KeywordArgError{Arg: "to", Cause: fn.ErrArgNotFound}
+		}
+
+		content, found := args["content"]
+		if !found {
+			return nil, &fn.KeywordArgError{Arg: "content", Cause: fn.ErrArgNotFound}
+		}
+
+		return fn.InvokerFunc(func(ctx context.Context) (interface{}, error) {
+			ct, ok := to.(string)
+			if !ok {
+				return nil, &fn.KeywordArgError{
+					Arg: "to",
+					Cause: &fn.UnexpectedTypeError{
+						Wanted: []reflect.Type{reflect.TypeOf("")},
+						Got:    reflect.TypeOf(to),
+					},
+				}
+			}
+
+			switch md := content.(type) {
+			case string:
+				r, err := convert.ConvertMarkdown(convert.ConvertType(ct), []byte(md))
+				if err != nil {
+					return nil, err
+				}
+				return string(r), nil
+			default:
+				return nil, &fn.KeywordArgError{
+					Arg: "content",
+					Cause: &fn.UnexpectedTypeError{
+						Wanted: []reflect.Type{reflect.TypeOf("")},
+						Got:    reflect.TypeOf(content),
+					},
+				}
+			}
+		}), nil
 	},
 }

--- a/pkg/workflow/spec/fnlib/convert.go
+++ b/pkg/workflow/spec/fnlib/convert.go
@@ -1,0 +1,49 @@
+package fnlib
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/convert"
+	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/fn"
+)
+
+var convertMarkdownDescriptor = fn.DescriptorFuncs{
+	DescriptionFunc: func() string { return "Converts a string in markdown format to another applicable syntax" },
+	PositionalInvokerFunc: func(args []interface{}) (fn.Invoker, error) {
+		fn := fn.InvokerFunc(func(ctx context.Context) (m interface{}, err error) {
+			if len(args) != 2 {
+				return nil, &fn.ArityError{Wanted: []int{2}, Variadic: true, Got: len(args)}
+			}
+
+			convertType, ok := args[0].(string)
+			if !ok {
+				return nil, &fn.PositionalArgError{
+					Arg: 0,
+					Cause: &fn.UnexpectedTypeError{
+						Wanted: []reflect.Type{reflect.TypeOf("")},
+						Got:    reflect.TypeOf(args[0]),
+					},
+				}
+			}
+
+			switch arg := args[1].(type) {
+			case string:
+				r, err := convert.ConvertMarkdown(convert.ConvertType(convertType), []byte(arg))
+				if err != nil {
+					return nil, err
+				}
+				return string(r), nil
+			default:
+				return nil, &fn.PositionalArgError{
+					Arg: 1,
+					Cause: &fn.UnexpectedTypeError{
+						Wanted: []reflect.Type{reflect.TypeOf("")},
+						Got:    reflect.TypeOf(args[1]),
+					},
+				}
+			}
+		})
+		return fn, nil
+	},
+}

--- a/pkg/workflow/spec/fnlib/convert_test.go
+++ b/pkg/workflow/spec/fnlib/convert_test.go
@@ -1,0 +1,40 @@
+package fnlib_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/convert"
+	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/fnlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertMarkdown(t *testing.T) {
+	desc, err := fnlib.Library().Descriptor("convertMarkdown")
+	require.NoError(t, err)
+
+	tcs := []struct {
+		Name     string
+		Markdown string
+		Expected string
+	}{
+		{
+			Name:     "Sample monitor event",
+			Markdown: "%%% @contact [![imageTitle](imageUrl)](imageRedirect) `data{context} > threshold` Detailed description. - - - [[linkTitle1](link1)] · [[linkTitle2](link2)] %%%",
+			Expected: "@contact \n\n[!imageUrl!|imageRedirect] {code}data{context} > threshold{code} Detailed description.\n----\n[[linkTitle1|link1]] · [[linkTitle2|link2]]",
+		},
+	}
+
+	for _, test := range tcs {
+		t.Run(fmt.Sprintf("%s", test.Name), func(t *testing.T) {
+			invoker, err := desc.PositionalInvoker([]interface{}{convert.ConvertTypeJira.String(), test.Markdown})
+			require.NoError(t, err)
+
+			r, err := invoker.Invoke(context.Background())
+			require.NoError(t, err)
+
+			require.Equal(t, test.Expected, r)
+		})
+	}
+}

--- a/pkg/workflow/spec/fnlib/convert_test.go
+++ b/pkg/workflow/spec/fnlib/convert_test.go
@@ -3,9 +3,11 @@ package fnlib_test
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/convert"
+	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/fn"
 	"github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/fnlib"
 	"github.com/stretchr/testify/require"
 )
@@ -15,26 +17,139 @@ func TestConvertMarkdown(t *testing.T) {
 	require.NoError(t, err)
 
 	tcs := []struct {
-		Name     string
-		Markdown string
-		Expected string
+		Name        string
+		ConvertType convert.ConvertType
+		Markdown    string
+		Expected    string
 	}{
 		{
-			Name:     "Sample monitor event",
-			Markdown: "%%% @contact [![imageTitle](imageUrl)](imageRedirect) `data{context} > threshold` Detailed description. - - - [[linkTitle1](link1)] · [[linkTitle2](link2)] %%%",
-			Expected: "@contact \n\n[!imageUrl!|imageRedirect] {code}data{context} > threshold{code} Detailed description.\n----\n[[linkTitle1|link1]] · [[linkTitle2|link2]]",
+			Name:        "Sample monitor event",
+			ConvertType: convert.ConvertTypeJira,
+			Markdown:    "%%% @contact [![imageTitle](imageUrl)](imageRedirect) `data{context} > threshold` Detailed description. - - - [[linkTitle1](link1)] · [[linkTitle2](link2)] %%%",
+			Expected:    "@contact \n\n[!imageUrl!|imageRedirect] {code}data{context} > threshold{code} Detailed description.\n----\n[[linkTitle1|link1]] · [[linkTitle2|link2]]",
 		},
 	}
 
 	for _, test := range tcs {
 		t.Run(fmt.Sprintf("%s", test.Name), func(t *testing.T) {
-			invoker, err := desc.PositionalInvoker([]interface{}{convert.ConvertTypeJira.String(), test.Markdown})
+			invoker, err := desc.PositionalInvoker([]interface{}{test.ConvertType.String(), test.Markdown})
 			require.NoError(t, err)
 
 			r, err := invoker.Invoke(context.Background())
 			require.NoError(t, err)
 
 			require.Equal(t, test.Expected, r)
+
+			invoker, err = desc.KeywordInvoker(map[string]interface{}{
+				"to":      test.ConvertType.String(),
+				"content": test.Markdown,
+			})
+
+			r, err = invoker.Invoke(context.Background())
+			require.NoError(t, err)
+
+			require.Equal(t, test.Expected, r)
+		})
+	}
+}
+
+func TestConvertMarkdownFunction(t *testing.T) {
+	desc, err := fnlib.Library().Descriptor("convertMarkdown")
+	require.NoError(t, err)
+
+	tcs := []struct {
+		Name                 string
+		Invoker              func() (fn.Invoker, error)
+		ExpectedInvokeError  error
+		ExpectedInvokerError error
+	}{
+		{
+			Name: "keyword invoker with unsupported convert type",
+			Invoker: func() (fn.Invoker, error) {
+				return desc.KeywordInvoker(map[string]interface{}{
+					"to":      "foo",
+					"content": "bar",
+				})
+			},
+			ExpectedInvokerError: convert.ErrConvertTypeNotSupported,
+		},
+		{
+			Name: "keyword invoker with invalid to keyword type",
+			Invoker: func() (fn.Invoker, error) {
+				return desc.KeywordInvoker(map[string]interface{}{
+					"to":      false,
+					"content": "bar",
+				})
+			},
+			ExpectedInvokerError: &fn.KeywordArgError{
+				Arg: "to",
+				Cause: &fn.UnexpectedTypeError{
+					Wanted: []reflect.Type{
+						reflect.TypeOf(""),
+					},
+					Got: reflect.TypeOf(false),
+				},
+			},
+		},
+		{
+			Name: "keyword invoker with invalid content keyword type",
+			Invoker: func() (fn.Invoker, error) {
+				return desc.KeywordInvoker(map[string]interface{}{
+					"to":      "jira",
+					"content": false,
+				})
+			},
+			ExpectedInvokerError: &fn.KeywordArgError{
+				Arg: "content",
+				Cause: &fn.UnexpectedTypeError{
+					Wanted: []reflect.Type{
+						reflect.TypeOf(""),
+					},
+					Got: reflect.TypeOf(false),
+				},
+			},
+		},
+		{
+			Name: "keyword invoker with missing to keyword",
+			Invoker: func() (fn.Invoker, error) {
+				return desc.KeywordInvoker(map[string]interface{}{
+					"content": "bar",
+				})
+			},
+			ExpectedInvokeError: &fn.KeywordArgError{
+				Arg:   "to",
+				Cause: fn.ErrArgNotFound,
+			},
+		},
+		{
+			Name: "keyword invoker with missing content",
+			Invoker: func() (fn.Invoker, error) {
+				return desc.KeywordInvoker(map[string]interface{}{
+					"to": "jira",
+				})
+			},
+			ExpectedInvokeError: &fn.KeywordArgError{
+				Arg:   "content",
+				Cause: fn.ErrArgNotFound,
+			},
+		},
+	}
+
+	for _, test := range tcs {
+		t.Run(fmt.Sprintf("%s", test.Name), func(t *testing.T) {
+			invoker, err := test.Invoker()
+			if test.ExpectedInvokeError != nil {
+				require.Equal(t, test.ExpectedInvokeError, err)
+			} else {
+				require.NoError(t, err)
+
+				_, err = invoker.Invoke(context.Background())
+				if test.ExpectedInvokerError != nil {
+					require.Equal(t, test.ExpectedInvokerError, err)
+				} else {
+					require.NoError(t, err)
+				}
+			}
 		})
 	}
 }

--- a/pkg/workflow/spec/fnlib/fnlib.go
+++ b/pkg/workflow/spec/fnlib/fnlib.go
@@ -6,11 +6,11 @@ var (
 	library = map[string]fn.Descriptor{
 		"append":          appendDescriptor,
 		"concat":          concatDescriptor,
+		"convertMarkdown": convertMarkdownDescriptor,
 		"equals":          equalsDescriptor,
 		"jsonUnmarshal":   jsonUnmarshalDescriptor,
 		"merge":           mergeDescriptor,
 		"notEquals":       notEqualsDescriptor,
-		"convertMarkdown": convertMarkdownDescriptor,
 	}
 )
 

--- a/pkg/workflow/spec/fnlib/fnlib.go
+++ b/pkg/workflow/spec/fnlib/fnlib.go
@@ -4,12 +4,13 @@ import "github.com/puppetlabs/nebula-sdk/pkg/workflow/spec/fn"
 
 var (
 	library = map[string]fn.Descriptor{
-		"append":        appendDescriptor,
-		"concat":        concatDescriptor,
-		"equals":        equalsDescriptor,
-		"jsonUnmarshal": jsonUnmarshalDescriptor,
-		"merge":         mergeDescriptor,
-		"notEquals":     notEqualsDescriptor,
+		"append":          appendDescriptor,
+		"concat":          concatDescriptor,
+		"equals":          equalsDescriptor,
+		"jsonUnmarshal":   jsonUnmarshalDescriptor,
+		"merge":           mergeDescriptor,
+		"notEquals":       notEqualsDescriptor,
+		"convertMarkdown": convertMarkdownDescriptor,
 	}
 )
 


### PR DESCRIPTION
Minimal (and somewhat rushed) implementation primarily aimed at supporting Datadog events in the short-term (and some specific workarounds for it).

Further support for Jira handling will be added later (and perhaps only as necessary).
This will be expanded to support Slack in the near-future.
Error handling will also need improved.

The render logic/implementation may or may not change in the future, but it is sufficient for our purposes now.