### PR TITLE
Adds documentation for the Python SDK

### DIFF
--- a/support/python/LICENSE.txt
+++ b/support/python/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2020, Puppet Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/support/python/MANIFEST.in
+++ b/support/python/MANIFEST.in
@@ -1,3 +1,5 @@
 include mypy.ini
 include tox.ini
+include LICENSE.txt
 recursive-include tests *.py
+recursive-include docs *.py *.rst

--- a/support/python/README.rst
+++ b/support/python/README.rst
@@ -1,0 +1,93 @@
+Relay Python SDK
+================
+
+This is the Python SDK for use with the internal `Relay <https://relay.sh>`_ service APIs.
+The SDK requires Python 3.8.
+
+It is intended for use by integration authors who are building containers to run 
+inside the service. For running workflows and interacting with the user-facing
+service APIs, use the `Relay CLI <https://github.com/puppetlabs/relay/>`_.
+
+The API documentation is auto-generated from the source code. Here are some
+higher-level examples that show the main SDK classes that integration authors
+will interact with.
+
+
+Installation
+------------
+
+The SDK is available to install via pip:
+
+.. code-block:: console
+
+  pip --no-cache-dir install "https://packages.nebula.puppet.net/sdk/support/python/v1/nebula_sdk-1-py3-none-any.whl"
+
+If you use the `relaysh/core:latest-python <https://hub.docker.com/r/relaysh/core/tags>`_ container image as your base
+image, it'll be pre-installed.
+
+Usage
+-----
+The main purpose of the SDK is to provide helpers for interacting with Relay's
+metadata service. Each container that runs in Relay has access to this service,
+which allows the container to read and write key-value data, emit events, and
+generate logs.
+
+Interface
+---------
+
+The `Interface class <./reference.html#module-nebula_sdk.interface>`_ is the primary way to interact with the SDK.
+Import it and instantiate an object, then call methods on that object to access metadata.
+Use the ``Dynamic`` class for getting data like connection credentials, 
+workflow-specific parameters, and secrets.
+
+.. code-block:: python
+
+  from nebula_sdk import Interface, Dynamic as D
+
+  relay = Interface()
+  param = relay.get(D.worflowparam)
+  secret = relay.get(D.mysecret)
+  relay.outputs.set("outputkey","This will be the value of outputkey")
+
+Webhooks
+--------
+
+The `Webhook class <./reference.html#module-nebula_sdk.webhook>`_ provides a
+helper that sets up a webserver to handle incoming requests for Trigger actions. 
+
+This example, from the `Dockerhub integration <https://github.com/relay-integrations/relay-dockerhub/>`_, makes use of
+the Interface class to access the ``events.emit`` method, which will cause
+the workflow associated with this trigger to be run with the inline mapping
+of workflow parameters to values extracted from the webhook payload.
+
+.. code-block:: python
+
+  from nebula_sdk import Interface, WebhookServer
+  from quart import Quart, request, jsonify, make_response
+
+  relay = Interface()
+  app = Quart('image-pushed')
+
+  @app.route('/', methods=['POST'])
+  async def handler():
+      event_payload = await request.get_json()
+
+      if event_payload is None:
+          return await make_response(jsonify(message='not a valid Docker Hub event'), 400)
+
+      pd = event_payload['push_data']
+      rd = event_payload['repository']
+
+      relay.events.emit({
+          'pushedAt': pd['pushed_at'],
+          'pusher': pd['pusher'],
+          'tag': pd['tag'],
+          'name': rd['repo_name']
+      })
+
+      return await make_response(jsonify(message='success'), 200)
+
+
+  if __name__ == '__main__':
+      WebhookServer(app).serve_forever()
+

--- a/support/python/README.rst
+++ b/support/python/README.rst
@@ -32,33 +32,43 @@ metadata service. Each container that runs in Relay has access to this service,
 which allows the container to read and write key-value data, emit events, and
 generate logs.
 
-Interface
----------
+Accessing Data from the step spec
+---------------------------------
 
-The `Interface class <./reference.html#module-nebula_sdk.interface>`_ is the primary way to interact with the SDK.
-Import it and instantiate an object, then call methods on that object to access metadata.
-Use the ``Dynamic`` class for getting data like connection credentials, 
-workflow-specific parameters, and secrets.
+The `Interface class <./reference.html#module-nebula_sdk.interface>`_ is the primary way to interact with the service.
+Import it and instantiate an object, then call methods on that object to access metadata,
+which comes from the ``spec`` section of the step and global Connection information.
+The ``Dynamic`` class provides syntactic sugar for getting data like connection credentials, 
+workflow-specific parameters, and secrets. It represents nested data structures as dot-separated
+method accessors.
 
 .. code-block:: python
 
   from nebula_sdk import Interface, Dynamic as D
 
   relay = Interface()
-  param = relay.get(D.worflowparam)
+  azuresecret = relay.get(D.azure.connection.secret) # using Dynamic
+  azureclient = relay.get('azure["connection"]["clientID"]') # same as above
   secret = relay.get(D.mysecret)
   relay.outputs.set("outputkey","This will be the value of outputkey")
 
-Webhooks
---------
+Webhook Triggers
+----------------
 
-The `Webhook class <./reference.html#module-nebula_sdk.webhook>`_ provides a
+The `WebhookServer class <./reference.html#module-nebula_sdk.webhook>`_ provides a
 helper that sets up a webserver to handle incoming requests for Trigger actions. 
 
-This example, from the `Dockerhub integration <https://github.com/relay-integrations/relay-dockerhub/>`_, makes use of
+This example, from the `Docker Hub integration <https://github.com/relay-integrations/relay-dockerhub/>`_, makes use of
 the Interface class to access the ``events.emit`` method, which will cause
 the workflow associated with this trigger to be run with the inline mapping
 of workflow parameters to values extracted from the webhook payload.
+
+The WebhookServer class can run any WSGI_ or ASGI_ application passed to it. The
+integrations the Relay team develops internally use the Quart_ web app framework.
+
+.. _WSGI: https://www.python.org/dev/peps/pep-3333/
+.. _ASGI: https://asgi.readthedocs.io/en/latest/specs/main.html
+.. _Quart: https://pgjones.gitlab.io/quart/index.html
 
 .. code-block:: python
 

--- a/support/python/docs/conf.py
+++ b/support/python/docs/conf.py
@@ -1,0 +1,11 @@
+import sys
+sys.path.append("./src")
+
+project = "Relay.sh SDK"
+author = "Puppet Inc"
+copyright = f"2020, {author}"
+extensions = [
+  "sphinx.ext.autodoc",
+  "sphinx.ext.napoleon",
+  "sphinx_autodoc_typehints"
+]

--- a/support/python/docs/index.rst
+++ b/support/python/docs/index.rst
@@ -1,0 +1,9 @@
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   license
+   reference
+ 
+.. include :: ../README.rst

--- a/support/python/docs/license.rst
+++ b/support/python/docs/license.rst
@@ -1,0 +1,4 @@
+License
+=======
+
+.. literalinclude:: ../LICENSE.txt

--- a/support/python/docs/reference.rst
+++ b/support/python/docs/reference.rst
@@ -1,0 +1,49 @@
+Relay SDK Reference Docs
+========================
+
+
+.. contents::
+    :local:
+    :backlinks: none
+
+These are auto-generated docs for the current version of the Python SDK
+
+----
+
+Client
+------
+
+.. automodule:: nebula_sdk.client
+   :members:
+
+----
+
+Events
+------
+
+.. automodule:: nebula_sdk.events
+   :members:
+
+----
+
+Interface
+---------
+
+.. automodule:: nebula_sdk.interface
+   :members:
+
+----
+
+Outputs
+-------
+
+.. automodule:: nebula_sdk.outputs
+   :members:
+
+----
+
+Webhook
+-------
+
+.. automodule:: nebula_sdk.webhook
+   :members:

--- a/support/python/setup.py
+++ b/support/python/setup.py
@@ -10,8 +10,8 @@ setuptools.setup(
     author_email='project-nebula-support@puppet.com',
     description='SDK for interacting with Project Nebula',
     url='https://github.com/puppetlabs/nebula-sdk',
-    packages=setuptools.find_packages('nebula_sdk'),
-    package_dir={'': 'nebula_sdk'},
+    packages=setuptools.find_packages('src'),
+    package_dir={'': 'src'},
     python_requires='>=3.8',
     setup_requires=[
         'setuptools_scm',

--- a/support/python/setup.py
+++ b/support/python/setup.py
@@ -10,8 +10,8 @@ setuptools.setup(
     author_email='project-nebula-support@puppet.com',
     description='SDK for interacting with Project Nebula',
     url='https://github.com/puppetlabs/nebula-sdk',
-    packages=setuptools.find_packages('src'),
-    package_dir={'': 'src'},
+    packages=setuptools.find_packages('nebula_sdk'),
+    package_dir={'': 'nebula_sdk'},
     python_requires='>=3.8',
     setup_requires=[
         'setuptools_scm',

--- a/support/python/src/nebula_sdk/__init__.py
+++ b/support/python/src/nebula_sdk/__init__.py
@@ -1,3 +1,4 @@
+"""A SDK for interacting with the relay.sh infrastructure services"""
 from .interface import Dynamic, Interface, UnresolvableException
 from .util import (NoTerminationPolicy, SignalTerminationPolicy,
                    SoftTerminationPolicy, TerminationPolicy)

--- a/support/python/src/nebula_sdk/client.py
+++ b/support/python/src/nebula_sdk/client.py
@@ -1,3 +1,4 @@
+"""Internal class for client sessions to interact with the Relay metadata service"""
 import os
 from typing import Mapping, Optional, Union
 from urllib.parse import urljoin, urlsplit, urlunsplit
@@ -24,6 +25,7 @@ class MetadataAPIAdapter(HTTPAdapter):
              cert: Optional[HTTPClientCertificate] = None,
              proxies: Optional[Mapping[str, str]] = None) -> Response:
         (_, _, path, query, fragment) = urlsplit(request.url or '')
+        """Sends a prepared http request to the metadata API server"""
         request.prepare_url(
             urljoin(
                 self._base_url,
@@ -43,6 +45,14 @@ class MetadataAPIAdapter(HTTPAdapter):
 
 
 def new_session(api_url: Optional[str] = None) -> Session:
+    """Create a new client session to the metadata API.
+
+    Args:
+        api_url: host and port to communicate with the api server (optional)
+
+    Returns:
+        a Session object connected to the api server
+    """
     sess = Session()
     sess.mount('http+api://', MetadataAPIAdapter(base_url=api_url))
     return sess

--- a/support/python/src/nebula_sdk/client.py
+++ b/support/python/src/nebula_sdk/client.py
@@ -1,4 +1,4 @@
-"""Internal class for client sessions to interact with the Relay metadata service"""
+"""Internal class for clients to interact with the metadata service"""
 import os
 from typing import Mapping, Optional, Union
 from urllib.parse import urljoin, urlsplit, urlunsplit

--- a/support/python/src/nebula_sdk/events.py
+++ b/support/python/src/nebula_sdk/events.py
@@ -1,3 +1,4 @@
+"Generating events for the service to act on"
 import json
 from typing import Any, Mapping
 
@@ -7,11 +8,20 @@ from .util import JSONEncoder
 
 
 class Events:
+    """Class for generating event payloads to the service API"""
 
     def __init__(self, client: Session) -> None:
         self._client = client
 
     def emit(self, data: Mapping[str, Any]) -> None:
+        """Create and send an event to the service.
+
+        Use this from a Trigger handler to start the workflow
+        associated with the trigger.
+
+        Accepts a Mapping of data fields that will bind
+        names of workflow parameters to values from the
+        request payload that came in to the Trigger handler"""
         r = self._client.post(
             'http+api://api/events',
             data=json.dumps({'data': data}, cls=JSONEncoder),

--- a/support/python/src/nebula_sdk/interface.py
+++ b/support/python/src/nebula_sdk/interface.py
@@ -1,3 +1,4 @@
+"The main class for a client to connect to the Relay service API"
 from __future__ import annotations
 
 import json
@@ -41,11 +42,23 @@ class Dynamic(metaclass=DynamicMetaclass):
 
 
 class Interface:
+    """An Interface object connects client code to the metadata service."""
 
     def __init__(self, api_url: Optional[str] = None):
         self._client = new_session(api_url=api_url)
 
     def get(self, q: Optional[Union[Dynamic, str]] = None) -> Any:
+        """Retrieve values from the metadata service
+
+        Args:
+            q: A particular parameter to query the value of.
+
+        Returns:
+            The value of the queried parameter as a string.
+            If no query was provided, all available parameters will be 
+            returned in a json map
+        """
+
         params = {}
         if q is not None:
             params['q'] = str(q)
@@ -61,8 +74,10 @@ class Interface:
 
     @property
     def events(self) -> Events:
+        """Accessor for Events methods"""
         return Events(self._client)
 
     @property
     def outputs(self) -> Outputs:
+        """Accessor for Outputs methods"""
         return Outputs(self._client)

--- a/support/python/src/nebula_sdk/interface.py
+++ b/support/python/src/nebula_sdk/interface.py
@@ -55,7 +55,7 @@ class Interface:
 
         Returns:
             The value of the queried parameter as a string.
-            If no query was provided, all available parameters will be 
+            If no query was provided, all available parameters will be
             returned in a json map
         """
 

--- a/support/python/src/nebula_sdk/outputs.py
+++ b/support/python/src/nebula_sdk/outputs.py
@@ -1,3 +1,4 @@
+"Outputs allow a step to write data that will be available for later steps"
 import json
 from typing import Any
 from urllib.parse import quote
@@ -8,11 +9,18 @@ from .util import JSONEncoder
 
 
 class Outputs:
-
+    "Use Outputs to write keys to the metadata service that later steps can retrieve"
     def __init__(self, client: Session) -> None:
         self._client = client
 
     def set(self, name: str, value: Any) -> None:
+        """Set writes a value of a given name to the service
+
+        Args:
+            name: a string containing the key name to write
+            value: the value of the key to be written. Can
+                be any data type that can serialize to JSON
+        """
         r = self._client.put(
             'http+api://api/outputs/{0}'.format(quote(name)),
             data=json.dumps(value, cls=JSONEncoder),

--- a/support/python/src/nebula_sdk/outputs.py
+++ b/support/python/src/nebula_sdk/outputs.py
@@ -9,7 +9,8 @@ from .util import JSONEncoder
 
 
 class Outputs:
-    "Use Outputs to write keys to the metadata service that later steps can retrieve"
+    """Use Outputs to write keys to the metadata service
+        that later steps can retrieve"""
     def __init__(self, client: Session) -> None:
         self._client = client
 

--- a/support/python/src/nebula_sdk/typing.py
+++ b/support/python/src/nebula_sdk/typing.py
@@ -1,3 +1,4 @@
+"""Local data types"""
 from typing import Container, Text, Tuple, Union
 
 HTTPTimeout = Union[float, Tuple[float, float], Tuple[float, None]]

--- a/support/python/src/nebula_sdk/util.py
+++ b/support/python/src/nebula_sdk/util.py
@@ -1,3 +1,4 @@
+"""Utility functions for interacting with the Relay service"""
 from __future__ import annotations
 
 import asyncio

--- a/support/python/src/nebula_sdk/webhook.py
+++ b/support/python/src/nebula_sdk/webhook.py
@@ -25,10 +25,8 @@ class PortParseError(Exception):
 
 class WebhookServer:
     """Instantiate a WebhookServer class to handle incoming webhook payloads
-    
-    Trigger webhook handlers should expect POST requests to the top level ('/')
 
-    They should use the serve_forever() startup method, because Relay 
+    They should use the serve_forever() startup method, because Relay
     will manage the lifecycle of the trigger container.
 
     They should not expect any state to be preserved between requests,

--- a/support/python/src/nebula_sdk/webhook.py
+++ b/support/python/src/nebula_sdk/webhook.py
@@ -1,3 +1,4 @@
+"""A helper class for building Trigger webhooks for Relay"""
 from __future__ import annotations
 
 import asyncio
@@ -23,6 +24,16 @@ class PortParseError(Exception):
 
 
 class WebhookServer:
+    """Instantiate a WebhookServer class to handle incoming webhook payloads
+    
+    Trigger webhook handlers should expect POST requests to the top level ('/')
+
+    They should use the serve_forever() startup method, because Relay 
+    will manage the lifecycle of the trigger container.
+
+    They should not expect any state to be preserved between requests,
+    nor rely on any persistence on the local container filesystem.
+    """
 
     _app: ASGIFramework
     _config: Config

--- a/support/python/tox.ini
+++ b/support/python/tox.ini
@@ -31,3 +31,12 @@ commands =
     flake8 src tests setup.py
     isort --check-only --diff --recursive src tests setup.py
     mypy --config-file {toxinidir}/mypy.ini src tests
+
+[testenv:docs]
+basepython = python3.8
+deps =
+  sphinx
+  sphinx-autodoc-typehints
+commands =
+  sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs/_build" --color -bhtml 
+  python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs/_build" / "index.html"))'


### PR DESCRIPTION
This commit adds inline API documentation for the python SDK.
There is a sphinx-based doc generation framework in docs/, and
a new tox environment to generate them:

    tox -e docs

The README.rst will both be displayed in the repo and pulled
into the generated docs site.