### PR TITLE
Add AWS session token to connection

### DIFF
--- a/pkg/model/spec.go
+++ b/pkg/model/spec.go
@@ -117,6 +117,7 @@ type AWSSpec struct {
 type AWSConnection struct {
 	AccessKeyID     string
 	SecretAccessKey string
+	SessionToken    string
 }
 
 type AWSDetails struct {
@@ -143,6 +144,10 @@ func (ad *AWSDetails) GetSecretAccessKey() string {
 
 	}
 	return ad.Connection.SecretAccessKey
+}
+
+func (ad *AWSDetails) GetSessionToken() string {
+	return ad.Connection.SessionToken
 }
 
 type GCPSpec struct {

--- a/pkg/task/aws.go
+++ b/pkg/task/aws.go
@@ -29,6 +29,11 @@ func (ti *TaskInterface) ProcessAWS(directory string) error {
 	creds.Section("default").Key("aws_access_key_id").SetValue(spec.AWS.GetAccessKeyID())
 	creds.Section("default").Key("aws_secret_access_key").SetValue(spec.AWS.GetSecretAccessKey())
 
+	sessionToken := spec.AWS.GetSessionToken()
+	if sessionToken != "" {
+		creds.Section("default").Key("aws_session_token").SetValue(sessionToken)
+	}
+
 	// .aws/config
 	config := ini.Empty()
 	if spec.AWS.Region != "" {


### PR DESCRIPTION
Adds the optional AWS Session Token to the AWS Connection.

**NOTE**: Connection models need to be sourced from a common location, rather than duplicated here...
